### PR TITLE
bug fix: set the default only if OkToReplace is true

### DIFF
--- a/prompt/library.go
+++ b/prompt/library.go
@@ -160,7 +160,7 @@ func (this *DiskPromptLibrary) ReplacePrompts(newPrompts []Prompt) {
 		index := this.ContainsPromptNamed(newPrompt.Name)
 		if index == -1 {
 			this.Prompts = append(this.Prompts, newPrompt)
-		} else {
+		} else if this.Prompts[index].OkToReplace {
 			this.Prompts[index] = newPrompt
 		}
 	}


### PR DESCRIPTION
Documentation said:

`If you edit a prompt then set OkToReplace: false, which prevents overwriting.`

It kept on overwriting it, I looked at the logs, then eventually the code.  I can't seem to see any condition that checks the OkToReplace field.  I then modified and did a new build; it now works as intended.