### PR TITLE
Add realtime terminal voice mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See also: [Butterfish Neovim plugin](https://github.com/bakks/butterfish.nvim)
 
 ## What is this thing?
 
-Butterfish is for people who work from the command line, it adds AI prompting to your shell (bash, zsh) with OpenAI. Think Github Copilot for shell.
+Butterfish is for people who work from the command line. It adds AI prompting to your shell (bash, zsh) with OpenAI, and it can also run a low-latency realtime voice session directly in the terminal. Think Github Copilot for shell.
 
 Here's how it works: use your shell as normal, start a command with a capital letter to prompt the AI. The AI sees the shell history, so you can ask contextual questions like "Why did that command fail?".
 
@@ -232,6 +232,32 @@ Some requests that fit Action Mode well:
 -   `@show the 10 largest files here`
 -   `@find all markdown files modified today`
 -   `@tail the latest app log`
+
+## Voice Mode
+
+Butterfish can open a realtime speech-to-speech session in the terminal:
+
+```bash
+butterfish --voice
+```
+
+The current implementation uses OpenAI's Realtime API with `gpt-realtime-1.5`,
+captures microphone audio with `ffmpeg`, and plays assistant audio with
+`ffplay`.
+
+While voice mode is running:
+
+-   Press `p` to pause or resume microphone streaming.
+-   Press `q` to quit the session.
+
+You can change the voice and hotkeys:
+
+```bash
+butterfish --voice --voice-name cedar --voice-pause-key x --voice-quit-key z
+```
+
+If `ffmpeg` needs a different microphone selector, set
+`BUTTERFISH_VOICE_INPUT`. On macOS the default is `:0`.
 
 ## Local Models
 

--- a/butterfish/butterfish.go
+++ b/butterfish/butterfish.go
@@ -95,6 +95,14 @@ type ButterfishConfig struct {
 	// Model and max tokens to use when executing the `exec` command
 	ExeccheckModel     string
 	ExeccheckMaxTokens int
+
+	// Realtime voice mode configuration
+	VoiceMode         bool
+	VoiceModel        string
+	VoiceVoice        string
+	VoiceInstructions string
+	VoicePauseKey     string
+	VoiceQuitKey      string
 }
 
 func (this *ButterfishConfig) ParseShell() string {
@@ -199,6 +207,11 @@ func MakeButterfishConfig() *ButterfishConfig {
 		GencmdMaxTokens:      512,
 		ExeccheckModel:       BestCompletionModel,
 		ExeccheckMaxTokens:   512,
+		VoiceModel:           "gpt-realtime-1.5",
+		VoiceVoice:           "marin",
+		VoicePauseKey:        "p",
+		VoiceQuitKey:         "q",
+		VoiceInstructions:    "You are Butterfish in a terminal voice session. Keep spoken responses concise and practical.",
 	}
 }
 

--- a/butterfish/voice.go
+++ b/butterfish/voice.go
@@ -1,0 +1,533 @@
+package butterfish
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/gorilla/websocket"
+	"golang.org/x/term"
+)
+
+type realtimeClientEvent struct {
+	Type    string `json:"type"`
+	EventID string `json:"event_id,omitempty"`
+}
+
+type realtimeSessionUpdateEvent struct {
+	Type    string         `json:"type"`
+	Session map[string]any `json:"session"`
+	EventID string         `json:"event_id,omitempty"`
+}
+
+type realtimeInputAudioAppendEvent struct {
+	Type  string `json:"type"`
+	Audio string `json:"audio"`
+}
+
+type realtimeSimpleEvent struct {
+	Type string `json:"type"`
+}
+
+type realtimeOutputAudioDeltaEvent struct {
+	Type  string `json:"type"`
+	Delta string `json:"delta"`
+}
+
+type realtimeTranscriptEvent struct {
+	Type       string `json:"type"`
+	Transcript string `json:"transcript"`
+}
+
+type realtimeTranscriptDeltaEvent struct {
+	Type  string `json:"type"`
+	Delta string `json:"delta"`
+}
+
+type realtimeErrorEvent struct {
+	Type  string `json:"type"`
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+
+type realtimeWriter struct {
+	conn *websocket.Conn
+	mu   sync.Mutex
+}
+
+func (w *realtimeWriter) WriteJSON(v any) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.conn.WriteJSON(v)
+}
+
+type pcmPlayer struct {
+	cmd   *exec.Cmd
+	stdin io.WriteCloser
+	mu    sync.Mutex
+}
+
+func RunVoice(ctx context.Context, config *ButterfishConfig) error {
+	if config.OpenAIToken == "" {
+		return errors.New("OPENAI_API_KEY is required for voice mode")
+	}
+
+	if err := requireExecutable("ffmpeg"); err != nil {
+		return err
+	}
+	if err := requireExecutable("ffplay"); err != nil {
+		return err
+	}
+
+	wsURL, err := realtimeWebSocketURL(config.BaseURL, config.VoiceModel)
+	if err != nil {
+		return err
+	}
+
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+config.OpenAIToken)
+
+	dialer := websocket.Dialer{
+		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+	}
+
+	conn, _, err := dialer.DialContext(ctx, wsURL, header)
+	if err != nil {
+		return fmt.Errorf("connect realtime websocket: %w", err)
+	}
+	defer conn.Close()
+
+	writer := &realtimeWriter{conn: conn}
+	player, err := startPCMPlayer(ctx)
+	if err != nil {
+		return err
+	}
+	defer player.Close()
+
+	micCmd, micStdout, err := startMicrophoneCapture(ctx)
+	if err != nil {
+		return err
+	}
+	defer stopCommand(micCmd)
+
+	if err := writer.WriteJSON(makeSessionUpdate(config)); err != nil {
+		return fmt.Errorf("send session.update: %w", err)
+	}
+	paused := atomic.Bool{}
+	paused.Store(false)
+	done := make(chan error, 3)
+	assistantStarted := atomic.Bool{}
+
+	fmt.Printf("Voice mode connected.\n")
+	fmt.Printf("Hotkeys: %s pause/unpause, %s quit\n", displayHotkey(config.VoicePauseKey), displayHotkey(config.VoiceQuitKey))
+
+	go func() {
+		done <- runRealtimeReadLoop(conn, player, &assistantStarted)
+	}()
+
+	go func() {
+		done <- streamMicrophone(micStdout, writer, &paused)
+	}()
+
+	go func() {
+		done <- captureVoiceHotkeys(ctx, &paused, writer, player, config.VoicePauseKey, config.VoiceQuitKey)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return err
+		}
+		return nil
+	}
+}
+
+func runRealtimeReadLoop(conn *websocket.Conn, player *pcmPlayer, assistantStarted *atomic.Bool) error {
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+
+		var event realtimeClientEvent
+		if err := json.Unmarshal(data, &event); err != nil {
+			continue
+		}
+
+		switch event.Type {
+		case "response.output_audio.delta":
+			var delta realtimeOutputAudioDeltaEvent
+			if err := json.Unmarshal(data, &delta); err != nil {
+				return err
+			}
+			audio, err := base64.StdEncoding.DecodeString(delta.Delta)
+			if err != nil {
+				return err
+			}
+			if !assistantStarted.Swap(true) {
+				fmt.Printf("\nButterfish: ")
+			}
+			if err := player.Write(audio); err != nil {
+				return err
+			}
+		case "response.output_audio_transcript.delta":
+			var delta realtimeTranscriptDeltaEvent
+			if err := json.Unmarshal(data, &delta); err != nil {
+				return err
+			}
+			fmt.Printf("%s", delta.Delta)
+		case "response.done":
+			if assistantStarted.Swap(false) {
+				fmt.Printf("\n")
+			}
+		case "conversation.item.input_audio_transcription.completed":
+			var transcript realtimeTranscriptEvent
+			if err := json.Unmarshal(data, &transcript); err != nil {
+				return err
+			}
+			if strings.TrimSpace(transcript.Transcript) != "" {
+				fmt.Printf("\nYou: %s\n", transcript.Transcript)
+			}
+		case "input_audio_buffer.speech_started":
+			player.Reset()
+		case "error":
+			var apiErr realtimeErrorEvent
+			if err := json.Unmarshal(data, &apiErr); err != nil {
+				return err
+			}
+			return fmt.Errorf("realtime API error (%s/%s): %s", apiErr.Error.Type, apiErr.Error.Code, apiErr.Error.Message)
+		}
+	}
+}
+
+func streamMicrophone(reader io.Reader, writer *realtimeWriter, paused *atomic.Bool) error {
+	bufReader := bufio.NewReaderSize(reader, 32*1024)
+	chunk := make([]byte, 4096)
+
+	for {
+		n, err := bufReader.Read(chunk)
+		if n > 0 && !paused.Load() {
+			payload := base64.StdEncoding.EncodeToString(chunk[:n])
+			if err := writer.WriteJSON(realtimeInputAudioAppendEvent{
+				Type:  "input_audio_buffer.append",
+				Audio: payload,
+			}); err != nil {
+				return err
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func captureVoiceHotkeys(ctx context.Context, paused *atomic.Bool, writer *realtimeWriter, player *pcmPlayer, pauseKey, quitKey string) error {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return errors.New("voice mode requires an interactive terminal for hotkeys")
+	}
+
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return err
+	}
+	defer term.Restore(int(os.Stdin.Fd()), oldState)
+
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		b, err := reader.ReadByte()
+		if err != nil {
+			return err
+		}
+
+		switch normalizeHotkeyByte(b) {
+		case normalizeHotkeyString(pauseKey):
+			newPaused := !paused.Load()
+			paused.Store(newPaused)
+			if newPaused {
+				player.Reset()
+				if err := writer.WriteJSON(realtimeSimpleEvent{Type: "input_audio_buffer.clear"}); err != nil {
+					return err
+				}
+				fmt.Printf("\n[paused]\n")
+			} else {
+				fmt.Printf("\n[listening]\n")
+			}
+		case normalizeHotkeyString(quitKey):
+			return context.Canceled
+		}
+	}
+}
+
+func makeSessionUpdate(config *ButterfishConfig) realtimeSessionUpdateEvent {
+	return realtimeSessionUpdateEvent{
+		Type: "session.update",
+		Session: map[string]any{
+			"type":         "realtime",
+			"instructions": strings.TrimSpace(config.VoiceInstructions),
+			"audio": map[string]any{
+				"input": map[string]any{
+					"turn_detection": map[string]any{
+						"type":               "server_vad",
+						"create_response":    true,
+						"interrupt_response": true,
+					},
+					"transcription": map[string]any{
+						"model": "gpt-4o-mini-transcribe",
+					},
+				},
+				"output": map[string]any{
+					"voice": config.VoiceVoice,
+				},
+			},
+		},
+	}
+}
+
+func realtimeWebSocketURL(baseURL, model string) (string, error) {
+	base := strings.TrimSpace(baseURL)
+	if base == "" {
+		base = "https://api.openai.com/v1/responses"
+	}
+
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse base url: %w", err)
+	}
+
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	case "wss", "ws":
+	default:
+		return "", fmt.Errorf("unsupported base url scheme %q", u.Scheme)
+	}
+
+	path := strings.TrimSuffix(u.Path, "/")
+	path = strings.TrimSuffix(path, "/responses")
+	path = strings.TrimSuffix(path, "/chat/completions")
+	if path == "" {
+		path = "/v1"
+	}
+	if !strings.HasSuffix(path, "/v1") {
+		path = strings.TrimRight(path, "/")
+	}
+	u.Path = strings.TrimRight(path, "/") + "/realtime"
+	q := u.Query()
+	q.Set("model", model)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func requireExecutable(name string) error {
+	if _, err := exec.LookPath(name); err != nil {
+		return fmt.Errorf("%s is required for voice mode", name)
+	}
+	return nil
+}
+
+func startMicrophoneCapture(ctx context.Context) (*exec.Cmd, io.ReadCloser, error) {
+	args, err := microphoneCaptureArgs()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
+	cmd.Stderr = io.Discard
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+	return cmd, stdout, nil
+}
+
+func microphoneCaptureArgs() ([]string, error) {
+	override := strings.TrimSpace(os.Getenv("BUTTERFISH_VOICE_INPUT"))
+	switch runtime.GOOS {
+	case "darwin":
+		input := ":0"
+		if override != "" {
+			input = override
+		}
+		return []string{
+			"-hide_banner", "-loglevel", "error",
+			"-f", "avfoundation",
+			"-i", input,
+			"-ac", "1",
+			"-ar", "24000",
+			"-f", "s16le",
+			"-",
+		}, nil
+	case "linux":
+		input := "default"
+		format := "pulse"
+		if override != "" {
+			input = override
+		}
+		return []string{
+			"-hide_banner", "-loglevel", "error",
+			"-f", format,
+			"-i", input,
+			"-ac", "1",
+			"-ar", "24000",
+			"-f", "s16le",
+			"-",
+		}, nil
+	default:
+		return nil, fmt.Errorf("voice mode microphone capture is not implemented for %s", runtime.GOOS)
+	}
+}
+
+func startPCMPlayer(ctx context.Context) (*pcmPlayer, error) {
+	cmd := exec.CommandContext(ctx, "ffplay",
+		"-nodisp",
+		"-loglevel", "quiet",
+		"-fflags", "nobuffer",
+		"-flags", "low_delay",
+		"-f", "s16le",
+		"-ar", "24000",
+		"-ac", "1",
+		"-",
+	)
+	cmd.Stderr = io.Discard
+	cmd.Stdout = io.Discard
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &pcmPlayer{
+		cmd:   cmd,
+		stdin: stdin,
+	}, nil
+}
+
+func (p *pcmPlayer) Write(data []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p == nil || p.stdin == nil {
+		return errors.New("audio player is not available")
+	}
+
+	if _, err := p.stdin.Write(data); err != nil {
+		if !isBrokenPipe(err) {
+			return err
+		}
+		if resetPCMPlayerLocked(p) != nil {
+			return err
+		}
+		_, retryErr := p.stdin.Write(data)
+		return retryErr
+	}
+
+	return nil
+}
+
+func (p *pcmPlayer) Reset() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return resetPCMPlayerLocked(p)
+}
+
+func (p *pcmPlayer) Close() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.stdin != nil {
+		_ = p.stdin.Close()
+	}
+	return stopCommand(p.cmd)
+}
+
+func resetPCMPlayerLocked(p *pcmPlayer) error {
+	if err := stopCommand(p.cmd); err != nil {
+		return err
+	}
+	next, err := startPCMPlayer(context.Background())
+	if err != nil {
+		return err
+	}
+	p.cmd = next.cmd
+	p.stdin = next.stdin
+	return nil
+}
+
+func stopCommand(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+	return nil
+}
+
+func isBrokenPipe(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "broken pipe")
+}
+
+func normalizeHotkeyByte(b byte) string {
+	return strings.ToLower(string([]byte{b}))
+}
+
+func normalizeHotkeyString(s string) string {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return ""
+	}
+	return string([]byte{s[0]})
+}
+
+func displayHotkey(s string) string {
+	normalized := normalizeHotkeyString(s)
+	if normalized == "" {
+		return "?"
+	}
+	return normalized
+}

--- a/butterfish/voice_test.go
+++ b/butterfish/voice_test.go
@@ -1,0 +1,73 @@
+package butterfish
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRealtimeWebSocketURL(t *testing.T) {
+	t.Parallel()
+
+	got, err := realtimeWebSocketURL("https://api.openai.com/v1/responses", "gpt-realtime-1.5")
+	require.NoError(t, err)
+	assert.Equal(t, "wss://api.openai.com/v1/realtime?model=gpt-realtime-1.5", got)
+
+	got, err = realtimeWebSocketURL("http://localhost:8080/v1/responses", "demo")
+	require.NoError(t, err)
+	assert.Equal(t, "ws://localhost:8080/v1/realtime?model=demo", got)
+}
+
+func TestNormalizeHotkeyString(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "p", normalizeHotkeyString("P"))
+	assert.Equal(t, "x", normalizeHotkeyString(" xyz "))
+	assert.Equal(t, "", normalizeHotkeyString(""))
+}
+
+func TestMicrophoneCaptureArgs(t *testing.T) {
+	t.Parallel()
+
+	old := os.Getenv("BUTTERFISH_VOICE_INPUT")
+	t.Cleanup(func() {
+		if old == "" {
+			_ = os.Unsetenv("BUTTERFISH_VOICE_INPUT")
+		} else {
+			_ = os.Setenv("BUTTERFISH_VOICE_INPUT", old)
+		}
+	})
+
+	_ = os.Setenv("BUTTERFISH_VOICE_INPUT", "custom-input")
+
+	args, err := microphoneCaptureArgs()
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		require.Error(t, err)
+		return
+	}
+
+	require.NoError(t, err)
+	assert.Contains(t, args, "custom-input")
+	assert.Contains(t, args, "-ar")
+	assert.Contains(t, args, "24000")
+}
+
+func TestMakeSessionUpdate(t *testing.T) {
+	t.Parallel()
+
+	cfg := MakeButterfishConfig()
+	cfg.VoiceInstructions = "test voice instructions"
+	cfg.VoiceVoice = "cedar"
+
+	event := makeSessionUpdate(cfg)
+	assert.Equal(t, "session.update", event.Type)
+	assert.Equal(t, "realtime", event.Session["type"])
+	assert.Equal(t, "test voice instructions", event.Session["instructions"])
+
+	audio := event.Session["audio"].(map[string]any)
+	output := audio["output"].(map[string]any)
+	assert.Equal(t, "cedar", output["voice"])
+}

--- a/cmd/butterfish/main.go
+++ b/cmd/butterfish/main.go
@@ -28,7 +28,7 @@ var ( // these are filled in at build time
 
 const description = `Do useful things with LLMs from the command line, with a bent towards software engineering.
 
-Butterfish is a command line tool for working with LLMs. It has two modes: CLI command mode, used to prompt LLMs and generate commands, and Shell mode: Wraps your local shell to provide easy prompting and autocomplete.
+Butterfish is a command line tool for working with LLMs. It supports CLI command mode for prompts and command generation, Shell mode for wrapping your local shell, and a realtime voice mode for low-latency speech in the terminal.
 
 Butterfish looks for an API key in OPENAI_API_KEY, or alternatively stores an OpenAI auth token at ~/.config/butterfish/butterfish.env.
 
@@ -74,12 +74,18 @@ func (v *VerboseFlag) BeforeResolve() error {
 // invoked, rather than when we're inside a butterfish console).
 // Kong will parse os.Args based on this struct.
 type CliConfig struct {
-	Verbose      VerboseFlag      `short:"v" default:"false" help:"Verbose mode, prints full LLM prompts (sometimes to log file). Use multiple times for more verbosity, e.g. -vv."`
-	Log          bool             `short:"L" default:"false" help:"Write verbose content to a log file rather than stdout, usually /var/tmp/butterfish.log"`
-	Version      kong.VersionFlag `short:"V" help:"Print version information and exit."`
-	BaseURL      string           `short:"u" default:"https://api.openai.com/v1/responses" help:"Base URL for OpenAI-compatible API. The default points directly at the Responses endpoint."`
-	TokenTimeout int              `short:"z" default:"30000" help:"Timeout before first prompt token is received and between individual tokens. In milliseconds."`
-	LightColor   bool             `short:"l" default:"false" help:"Light color mode, appropriate for a terminal with a white(ish) background"`
+	Verbose       VerboseFlag      `short:"v" default:"false" help:"Verbose mode, prints full LLM prompts (sometimes to log file). Use multiple times for more verbosity, e.g. -vv."`
+	Log           bool             `short:"L" default:"false" help:"Write verbose content to a log file rather than stdout, usually /var/tmp/butterfish.log"`
+	Version       kong.VersionFlag `short:"V" help:"Print version information and exit."`
+	BaseURL       string           `short:"u" default:"https://api.openai.com/v1/responses" help:"Base URL for OpenAI-compatible API. The default points directly at the Responses endpoint."`
+	TokenTimeout  int              `short:"z" default:"30000" help:"Timeout before first prompt token is received and between individual tokens. In milliseconds."`
+	LightColor    bool             `short:"l" default:"false" help:"Light color mode, appropriate for a terminal with a white(ish) background"`
+	Voice         bool             `name:"voice" default:"false" help:"Start realtime voice mode in the terminal."`
+	VoiceModel    string           `name:"voice-model" default:"gpt-realtime-1.5" help:"Realtime model to use for voice mode."`
+	VoiceName     string           `name:"voice-name" default:"marin" help:"Voice preset for audio output in voice mode."`
+	VoicePrompt   string           `name:"voice-prompt" default:"You are Butterfish in a terminal voice session. Keep spoken responses concise and practical." help:"Instructions for the voice session."`
+	VoicePauseKey string           `name:"voice-pause-key" default:"p" help:"Single-key hotkey used to pause or resume microphone streaming in voice mode."`
+	VoiceQuitKey  string           `name:"voice-quit-key" default:"q" help:"Single-key hotkey used to exit voice mode."`
 
 	Shell struct {
 		Bin                       string `short:"b" help:"Shell to use (e.g. /bin/zsh), defaults to $SHELL."`
@@ -98,6 +104,21 @@ type CliConfig struct {
 	// We include the cliConsole options here so that we can parse them and hand them
 	// to the console executor, even though we're in the shell context here
 	bf.CliCommandConfig
+}
+
+type VoiceCliConfig struct {
+	Verbose       VerboseFlag      `short:"v" default:"false" help:"Verbose mode, prints full LLM prompts (sometimes to log file). Use multiple times for more verbosity, e.g. -vv."`
+	Log           bool             `short:"L" default:"false" help:"Write verbose content to a log file rather than stdout, usually /var/tmp/butterfish.log"`
+	Version       kong.VersionFlag `short:"V" help:"Print version information and exit."`
+	BaseURL       string           `short:"u" default:"https://api.openai.com/v1/responses" help:"Base URL for OpenAI-compatible API. The default points directly at the Responses endpoint."`
+	TokenTimeout  int              `short:"z" default:"30000" help:"Timeout before first prompt token is received and between individual tokens. In milliseconds."`
+	LightColor    bool             `short:"l" default:"false" help:"Light color mode, appropriate for a terminal with a white(ish) background"`
+	Voice         bool             `name:"voice" default:"false" help:"Start realtime voice mode in the terminal."`
+	VoiceModel    string           `name:"voice-model" default:"gpt-realtime-1.5" help:"Realtime model to use for voice mode."`
+	VoiceName     string           `name:"voice-name" default:"marin" help:"Voice preset for audio output in voice mode."`
+	VoicePrompt   string           `name:"voice-prompt" default:"You are Butterfish in a terminal voice session. Keep spoken responses concise and practical." help:"Instructions for the voice session."`
+	VoicePauseKey string           `name:"voice-pause-key" default:"p" help:"Single-key hotkey used to pause or resume microphone streaming in voice mode."`
+	VoiceQuitKey  string           `name:"voice-quit-key" default:"q" help:"Single-key hotkey used to exit voice mode."`
 }
 
 func getOpenAIToken() string {
@@ -172,6 +193,37 @@ func makeButterfishConfig(options *CliConfig) *bf.ButterfishConfig {
 	return config
 }
 
+func makeVoiceButterfishConfig(options *VoiceCliConfig) *bf.ButterfishConfig {
+	config := bf.MakeButterfishConfig()
+	config.OpenAIToken = getOpenAIToken()
+	config.BaseURL = options.BaseURL
+	config.PromptLibraryPath = defaultPromptPath
+	config.TokenTimeout = time.Duration(options.TokenTimeout) * time.Millisecond
+	config.ColorDark = !options.LightColor
+
+	if options.Verbose {
+		config.Verbose = verboseCount
+	}
+
+	config.VoiceMode = true
+	config.VoiceModel = options.VoiceModel
+	config.VoiceVoice = options.VoiceName
+	config.VoiceInstructions = options.VoicePrompt
+	config.VoicePauseKey = options.VoicePauseKey
+	config.VoiceQuitKey = options.VoiceQuitKey
+
+	return config
+}
+
+func wantsVoiceMode(args []string) bool {
+	for _, arg := range args {
+		if arg == "--voice" {
+			return true
+		}
+	}
+	return false
+}
+
 func getBuildInfo() string {
 	buildOs := runtime.GOOS
 	buildArch := runtime.GOARCH
@@ -185,6 +237,35 @@ func main() {
 	// }()
 
 	desc := fmt.Sprintf("%s\n%s", description, getBuildInfo())
+
+	if wantsVoiceMode(os.Args[1:]) {
+		voiceCli := &VoiceCliConfig{}
+		voiceParser, err := kong.New(voiceCli,
+			kong.Name("butterfish"),
+			kong.Description(desc),
+			kong.UsageOnError(),
+			kong.Vars{
+				"version": getBuildInfo(),
+			})
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = voiceParser.Parse(os.Args[1:])
+		voiceParser.FatalIfErrorf(err)
+
+		config := makeVoiceButterfishConfig(voiceCli)
+		config.BuildInfo = getBuildInfo()
+		ctx := context.Background()
+		errorWriter := util.NewStyledWriter(os.Stderr, config.Styles.Error)
+
+		if err := bf.RunVoice(ctx, config); err != nil {
+			fmt.Fprint(errorWriter, err.Error())
+			os.Exit(5)
+		}
+		return
+	}
+
 	cli := &CliConfig{}
 
 	cliParser, err := kong.New(cli,

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/bakks/tiktoken-go v0.1.4-bakks-2
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creack/pty v1.1.24
+	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=


### PR DESCRIPTION
## Summary

  This PR adds a realtime voice mode to Butterfish so you can run `butterfish --voice`, speak to
  the model, and pause/resume mic capture from the keyboard.

  ## What Changed

  - added terminal voice mode backed by the OpenAI Realtime API
  - added top-level `--voice` flags:
    - `--voice`
    - `--voice-model`
    - `--voice-name`
    - `--voice-pause-key`
    - `--voice-quit-key`
    - `--voice-prompt`
  - added realtime websocket session setup and event handling
  - added microphone capture via `ffmpeg`
  - added assistant audio playback via `ffplay`
  - added pause/resume hotkey support
  - added `BUTTERFISH_VOICE_INPUT` override for selecting a specific mic device
  - fixed root CLI parsing so `butterfish --voice` works without requiring a subcommand
  - made audio playback more resilient by restarting the player on broken-pipe failures
  - added focused tests for realtime URL building, hotkey normalization, mic capture args, and
  session payload generation
  - documented voice mode usage in the README

  ## Notes

  - on macOS, microphone selection may need `BUTTERFISH_VOICE_INPUT=":<index>"`
  - in local testing, `MacBook Air Microphone` was AVFoundation device `:2`
  - the broader PTY integration tests still have existing environment-specific failures unrelated
  to this PR

  ## Verification

  - built the CLI successfully
  - verified `butterfish --voice --help` resolves through the top-level voice path
  - verified local transcription works with the correct AVFoundation mic input
  - ran focused voice tests:
    - `./butterfish/bin/go-local test ./butterfish -run 'TestRealtimeWebSocketURL|
  TestNormalizeHotkeyString|TestMicrophoneCaptureArgs|TestMakeSessionUpdate'`

  go hoos